### PR TITLE
Prevent flickering when hovering the Solution tip

### DIFF
--- a/css/main-section.css
+++ b/css/main-section.css
@@ -224,6 +224,7 @@
 
 /* Tooltips */
 .box.solution .tooltip {
+  pointer-events: none;
   width: 160px;
   margin-left: 160px;
   margin-top: 16px;


### PR DESCRIPTION
When you hover over the "Solution" section's tip, it disappears (because you're not longer hovering `.box-content`) and then reappears and flickers on and off...

Thanks to @rokdazone for the [tip](https://github.com/valor-software/ngx-bootstrap/issues/3075#issuecomment-363461060).

Tested/Validated on Chrome.