### PR TITLE
Upgrade jQuery 1.x to 3.5.1.

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
     </div>
     <a href="https://github.com/mbinette91/ffx2-sphere-break"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
   </body>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   <script src="js/utils.js"></script>
   <script src="js/spherebreak.js"></script>
   <script src="js/input.js"></script>


### PR DESCRIPTION
jQuery 1.11.3 was released in 2015, so it's long overdue for an update.

Verified by playing a quick game locally. I forgot the rules, but numbers were showing up on the right and I assume they were right. /shrug