### PR TITLE
Migrate to Bootstrap 4.

### DIFF
--- a/css/main-section.css
+++ b/css/main-section.css
@@ -109,11 +109,17 @@
   float: left;
 }
 
-.actions button{
+.actions button.btn {
   margin-top: 5px;
+  font-size: inherit;
+  line-height: inherit;
 }
 
 /* Grid */
+.row {
+  display: block;
+}
+
 .coin {
   position: relative;
   z-index: 1;
@@ -157,6 +163,7 @@
   box-shadow: 2px 2px 3px rgba(200,200,200,0.5),
              -2px -2px 3px rgba(200,200,200,0.5);
   z-index: 2;
+  color: inherit;
 }
 
 .ss-right {
@@ -223,9 +230,14 @@
 }
 
 /* Tooltips */
-.box.solution .tooltip {
+.tooltip.solution {
   pointer-events: none;
   width: 160px;
-  margin-left: 160px;
-  margin-top: 16px;
+  left: 160px !important;
+  top: 16px !important;
 }
+
+.tooltip {
+  font-size: 12px;
+}
+

--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,50 @@ textarea:focus, input:focus { outline: 0; }
 input::-webkit-outer-spin-button, input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 input[type="number"] { -moz-appearance: textfield; }
 
+/* Default styles */
+body {
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.42857143;
+  color: #333;
+}
+
+h2, h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+h2 {
+  font-size: 30px;
+}
+
+h3 {
+    font-size: 24px;
+}
+
+input[type=checkbox] {
+  margin: 4px 0 0;
+}
+
+input[type=radio] {
+  margin: 2px 0 0;
+}
+
+blockquote {
+  padding: 10px 20px;
+  margin: 0 0 20px;
+  border-left: 5px solid #eee;
+}
+
+blockquote footer:before {
+    content: '\2014 \00A0';
+}
+
+blockquote footer {
+    font-size: 90%;
+    color: #777;
+}
+
 /* Section (general) */
 .section {
   clear: both;

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <link rel="shortcut icon" type="image/png" href="favicon.png"/>
     <link rel="image_src" href="http://mbinette91.github.io/ffx2-sphere-break/favicon.png"/>
     <meta property="og:image" content="http://mbinette91.github.io/ffx2-sphere-break/favicon.png" />
-    <link rel="stylesheet" type="text/css" href="css/style.css"/>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="css/style.css"/>
   </head>
   <body>
     <div id="main-section" class="section">
@@ -43,7 +43,11 @@
 
         <div class="subsection ss-right">
           <div class="solution box">
-            <div class="box-content" data-toggle="tooltip" data-placement="left" title="This is the best solution found by the algorithm. Make sure to input it in the right order.">
+            <div class="box-content"
+                 data-toggle="tooltip"
+                 data-placement="left"
+                 data-template="<div class='tooltip solution' role='tooltip'><div class='arrow'></div><div class='tooltip-inner'></div></div>"
+                 title="This is the best solution found by the algorithm. Make sure to input it in the right order.">
               <div class="box-title">Solution</div>
               <div class="score">Score: <span id="score"></span></div>
               <div class="echo-results">

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="image_src" href="http://mbinette91.github.io/ffx2-sphere-break/favicon.png"/>
     <meta property="og:image" content="http://mbinette91.github.io/ffx2-sphere-break/favicon.png" />
     <link rel="stylesheet" type="text/css" href="css/style.css"/>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
   </head>
   <body>
     <div id="main-section" class="section">
@@ -206,10 +206,11 @@
     </div>
     <a href="https://github.com/mbinette91/ffx2-sphere-break"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
   </body>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
   <script src="js/utils.js"></script>
   <script src="js/spherebreak.js"></script>
   <script src="js/input.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" integrity="sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
   <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create', 'UA-28781654-4', 'auto');ga('send', 'pageview');</script>
 </html>


### PR DESCRIPTION
Migrate to Bootstrap 4.

Our bootstrap version was also in need of an update.

Notable changes for us, from 3 -> 4:

1- Popper is a required dependency to use tooltips.
2- Bootstrap css now includes reboot. We were relying on browser defaults for a lot of our styling, so had to explicitely set the stuff we care about.

https://getbootstrap.com/docs/4.0/migration/