### PR TITLE
Implement auto-update toggle for input changes.

### DIFF
--- a/css/main-section.css
+++ b/css/main-section.css
@@ -109,10 +109,25 @@
   float: left;
 }
 
-.actions button.btn {
+#action-advance-turn, #find-solution-container {
   margin-top: 5px;
+}
+
+.actions .btn {
   font-size: inherit;
   line-height: inherit;
+}
+
+#find-solution-container {
+  position: relative;
+}
+
+#find-solution-toggle-container {
+  min-width: 80px;
+  transform: scale(0.75);
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 /* Grid */

--- a/index.html
+++ b/index.html
@@ -119,8 +119,13 @@
           </div>
 
           <div class="actions">
-            <button id="action-find-solution" class="btn btn-primary btn-block" data-toggle="tooltip" data-placement="bottom" title="Update the 'Solution' box">Find solution</button>
-            <button id="action-advance-turn" class="btn btn-success btn-block" data-toggle="tooltip" data-placement="top" title="Increments all border coins by 1">Advance turn</button>
+            <button id="action-advance-turn" class="btn btn-success btn-block" data-toggle="tooltip" data-placement="bottom" title="Increments all border coins by 1">Advance turn</button>
+            <div id="find-solution-container">
+              <button id="action-find-solution" class="btn btn-primary btn-block" data-toggle="tooltip" data-placement="top" title="Update the 'Solution' box">Find solution</button>
+              <span id="find-solution-toggle-container" data-toggle="tooltip" data-placement="top" title="Automatically update the 'Solution' box when data changes">
+                <input id="find-solution-toggle" type="checkbox" checked data-toggle="toggle" data-on="Auto" data-off="Manual" data-onstyle="success" data-offstyle="secondary"/>
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="image_src" href="http://mbinette91.github.io/ffx2-sphere-break/favicon.png"/>
     <meta property="og:image" content="http://mbinette91.github.io/ffx2-sphere-break/favicon.png" />
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/css/bootstrap4-toggle.min.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="css/style.css"/>
   </head>
   <body>
@@ -216,5 +217,6 @@
   <script src="js/input.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/js/bootstrap4-toggle.min.js"></script>
   <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create', 'UA-28781654-4', 'auto');ga('send', 'pageview');</script>
 </html>

--- a/js/input.js
+++ b/js/input.js
@@ -46,18 +46,46 @@ $(function () {
   // Initialize controller and main functions
   var controller = new SphereBreakController();
 
-  $("#main-section input").on('change', function(){
-    controller.findCurrentSolution();
-  });
+  var isAutoUpdateSolutionOn = function() {
+    return $("#find-solution-toggle").prop('checked');
+  }
 
-  $("#action-find-solution").on('click', function() {
-    controller.findCurrentSolution();
+  var staleSolution = false;
+  $("#main-section input").on('change', function() {
+    if($(this).is($("#find-solution-toggle")))
+      return; // We have a different handler for this below.
+
+    if (isAutoUpdateSolutionOn()) {
+      controller.findCurrentSolution();
+      staleSolution = false;
+    }
+    else {
+      staleSolution = true;
+    }
   });
 
   $("#action-advance-turn").on('click', function(){
     controller.advanceTurn();
     controller.findCurrentSolution(); // Refresh.
+    staleSolution = false;
   });
+
+  $("#action-find-solution").on('click', function() {
+    controller.findCurrentSolution();
+    staleSolution = false;
+  });
+
+  // Initialize the FindSolution button & toggle
+  $("#find-solution-toggle").change(function(){
+    $("#action-find-solution").prop('disabled', isAutoUpdateSolutionOn());
+    if (isAutoUpdateSolutionOn() && staleSolution) {
+      controller.findCurrentSolution();
+      staleSolution = false;
+    }
+  });
+
+  $("#action-find-solution").prop('disabled', isAutoUpdateSolutionOn());
+
 })
 
 /* Tooltips */


### PR DESCRIPTION
Some parameters make find `findCurrentSolution` really slow, which is painful when updating the main grid between turns.

Added a toggle (https://gitbrent.github.io/bootstrap4-toggle/) to turn that behavior on and off, and some logic around stale data to automatically trigger an update when re-enabling the toggle if needed.

Fixes #9 